### PR TITLE
Prevent emitions after completion

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,10 +6,11 @@ const fromIter = iter => (start, sink) => {
       : iter;
   let inloop = false;
   let got1 = false;
+  let completed = false;
   let res;
   function loop() {
     inloop = true;
-    while (got1) {
+    while (got1 && !completed) {
       got1 = false;
       res = iterator.next();
       if (res.done) sink(2);
@@ -18,9 +19,13 @@ const fromIter = iter => (start, sink) => {
     inloop = false;
   }
   sink(0, t => {
+    if (completed) return
+
     if (t === 1) {
       got1 = true;
       if (!inloop && !(res && res.done)) loop();
+    } else if (t === 2) {
+      completed = true;
     }
   });
 };

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
   },
   "author": "staltz.com",
   "license": "MIT",
-  "keywords": ["callbag"],
+  "keywords": [
+    "callbag"
+  ],
   "devDependencies": {
     "tape": "^4.8.0"
   }

--- a/test.js
+++ b/test.js
@@ -95,3 +95,35 @@ test('it does not blow up the stack when iterating something huge', t => {
   });
   t.equals(iterated, true, 'iteration happened synchronously');
 });
+
+test('it stops sending after source completion', t => {
+  t.plan(5);
+  const source = fromIter([10, 20, 30]);
+
+  const actual = [];
+  const downwardsExpectedTypes = [
+    [0, 'function'],
+    [1, 'number'],
+  ];
+
+  let talkback;
+  source(0, (type, data) => {
+    const et = downwardsExpectedTypes.shift();
+    t.equals(type, et[0], 'downwards type is expected: ' + et[0]);
+    t.equals(typeof data, et[1], 'downwards data type is expected: ' + et[1]);
+
+    if (type === 0) {
+      talkback = data;
+      talkback(1);
+      return;
+    }
+    if (type === 1) {
+      actual.push(data);
+      talkback(2);
+      talkback(1);
+      talkback(1);
+    }
+  });
+
+  t.deepEquals(actual, [10]);
+});


### PR DESCRIPTION
Real world scenario:
```js
pipe(
  fromIter([1,2,3]),
  first(),
  forEach(value => console.log(value))
)
```

operator such as `first` has to do this:
```js
talkback(2)
sink(1, data)
sink(2)
```

but at the moment of sending `1` to the sink it has the opportunity to ask for more items ([like here](https://github.com/staltz/callbag-for-each/blob/5f80175ae89c68375e0290d5acec2e57ed0d408f/readme.js#L45)) as it doesn't know that in a moment it will get notified about the end. This caused a problem because the source (`fromIter`) produced next value.